### PR TITLE
Package name update. [WARNING: This is a backward compatibility breaking change!]

### DIFF
--- a/lib/services/backup/backup_manager.dart
+++ b/lib/services/backup/backup_manager.dart
@@ -8,8 +8,8 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:archive/archive_io.dart';
-import '../../utils/app_logger.dart';
 
+import '../../utils/app_logger.dart';
 import '../../database/music_piece_repository.dart';
 import '../../models/music_piece.dart';
 import '../../models/tag.dart';


### PR DESCRIPTION
# WARNING: This is a backward compatibility breaking change!
Updates the app package name to the final one from the placeholder value. 
> Please create a backup or restore from an auto-backup or manual-backup to keep your data. 

> Make sure the old version is uninstalled after creating a backup - before installing the newer version.