### PR TITLE
moves from syncviewer_flutter_pdfviewer to the open source pdfrx.

### DIFF
--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:syncfusion_flutter_pdfviewer/pdfviewer.dart';
-import 'dart:io';
+import 'package:pdfrx/pdfrx.dart';
 
 /// A screen for viewing PDF documents.
 ///
-/// This screen utilizes the `syncfusion_flutter_pdfviewer` package to display
+/// This screen utilizes the `pdfrx` package to display
 /// PDF files from a given local path.
 class PdfViewerScreen extends StatelessWidget {
   final String pdfPath; // The local file path of the PDF document to display.
@@ -17,7 +16,7 @@ class PdfViewerScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('PDF Viewer'), // Title of the PDF viewer screen.
       ),
-      body: SfPdfViewer.file(File(pdfPath)), // Display the PDF from the file path.
+      body: PdfView.file(pdfPath), // Display the PDF from the file path.
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   uuid: ^4.2.1 # For generating unique IDs
   http: ^1.1.0 # For making HTTP requests
   file_picker: ^10.2.0 # For picking files from local storage
-  syncfusion_flutter_pdfviewer: ^30.2.6 # Or another PDF viewer
+  pdfrx: ^1.0.50 # Or another PDF viewer
   flutter_markdown: ^0.7.7+1 # For rendering markdown
   photo_view: ^0.15.0 # For zoomable images
   just_audio: ^0.10.4 # For audio playback


### PR DESCRIPTION
Mainly for fdroid compatibility. We want everything to be open source to be compatible. It's a drop in replacement and changes nothing on the front end, so next the release cam be just a minor version update.