### PR TITLE
Allow zooming out past fit scale in PDF viewer

### DIFF
--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -41,6 +41,7 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
   int _currentPage = 1;
   bool _isDraggingScrollbar = false;
   Duration _lastUpdateElapsed = Duration.zero;
+  double _fitScale = 1.0;
 
   late AnimationController _scrollbarOpacityController;
   Timer? _scrollbarHideTimer;
@@ -227,19 +228,18 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
   void _handleDoubleTap() {
     if (!_pdfViewerController.isReady) return;
     final currentZoom = _pdfViewerController.currentZoom;
-    final minZoom = _pdfViewerController.minScale;
 
     // Zoom out to fit page width if we are currently zoomed in
-    if (currentZoom > minZoom + 0.01) {
+    if (currentZoom > _fitScale + 0.01) {
       _pdfViewerController.setZoom(
         _pdfViewerController.centerPosition,
-        minZoom,
+        _fitScale,
       );
     } else {
       // Zoom in to 2.0 times the fit zoom (minScale)
       _pdfViewerController.setZoom(
         _pdfViewerController.centerPosition,
-        minZoom * 2.0,
+        _fitScale * 2.0,
       );
     }
   }
@@ -410,6 +410,8 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
                 controller: _pdfViewerController,
                 params: PdfViewerParams(
                   margin: 8.0,
+                  minScale: 0.5,
+                  useAlternativeFitScaleAsMinScale: false,
                   behaviorControlParams: const PdfViewerBehaviorControlParams(
                     pageImageCachingDelay: Duration.zero,
                     partialImageLoadingDelay: Duration.zero,
@@ -419,6 +421,11 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
                       setState(() {
                         _isLoaded = true;
                         _document = document;
+                      });
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (mounted && controller.isReady) {
+                          _fitScale = controller.currentZoom;
+                        }
                       });
                     }
                   },

--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -41,7 +41,6 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
   int _currentPage = 1;
   bool _isDraggingScrollbar = false;
   Duration _lastUpdateElapsed = Duration.zero;
-  double _fitScale = 1.0;
 
   late AnimationController _scrollbarOpacityController;
   Timer? _scrollbarHideTimer;
@@ -230,16 +229,22 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
     final currentZoom = _pdfViewerController.currentZoom;
 
     // Zoom out to fit page width if we are currently zoomed in
-    if (currentZoom > _fitScale + 0.01) {
+    final double fitScale = _pdfViewerController.alternativeFitScale == null
+        ? _pdfViewerController.coverScale
+        : math.min(
+            _pdfViewerController.coverScale,
+            _pdfViewerController.alternativeFitScale!,
+          );
+
+    if (currentZoom > fitScale + 0.01) {
       _pdfViewerController.setZoom(
         _pdfViewerController.centerPosition,
-        _fitScale,
+        fitScale,
       );
     } else {
-      // Zoom in to 2.0 times the fit zoom (minScale)
       _pdfViewerController.setZoom(
         _pdfViewerController.centerPosition,
-        _fitScale * 2.0,
+        fitScale * 2.0,
       );
     }
   }
@@ -421,11 +426,6 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
                       setState(() {
                         _isLoaded = true;
                         _document = document;
-                      });
-                      WidgetsBinding.instance.addPostFrameCallback((_) {
-                        if (mounted && controller.isReady) {
-                          _fitScale = controller.currentZoom;
-                        }
                       });
                     }
                   },


### PR DESCRIPTION
Fixes #229 : Allow zooming out past fit scale in PDF viewer

Problem:
The PDF viewer capped zoom-out at the fit-to-page scale, so users on landscape tablets (and other wide-viewport cases) couldn't zoom out further to see more of the page at once.

Root cause:
PdfViewerParams defaults to useAlternativeFitScaleAsMinScale: true, which makes PdfViewerController.minScale return the computed fit-to-page scale regardless of the configured minScale value.

Changes:
1. Set minScale: 0.5 and useAlternativeFitScaleAsMinScale: false in PdfViewerParams, so controller.minScale now returns the raw configured value instead of the fit scale.
2. Added a _fitScale field that captures the actual fit-to-page scale once in onViewerReady, since controller.minScale no longer represents it.
3. Updated _handleDoubleTap to use _fitScale instead of controller.minScale for its fit / 2x-fit toggle logic, which previously relied on the old (now incorrect) assumption that minScale == fit scale.

Notes for reviewers:
pdfrx's own docs note useAlternativeFitScaleAsMinScale: false is "not recommended... may degrade viewer performance." Also, this gets depricated from version 2.3.0 and onwards in favor of sizeDelegateProvider, but this repo is pinned to pdfrx: ^2.2.24, which resolves below that boundary via pubspec.lock. No deprecation warnings on the current resolved version.