### PR TITLE
feat: comprehensive media player polish, pdf bookmarks, and quality of life improvements

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -167,17 +167,6 @@ jobs:
           zip -r web_build.zip web_build/
           cd ..
 
-      - name: Generate Nightly Checksums
-        if: steps.changes.outputs.has_changes == 'true' || github.event_name != 'schedule'
-        run: |
-          cd nightly_assets
-          for file in *.apk *.aab; do
-            if [ -f "$file" ]; then
-              sha256sum "$file" > "$file.sha256"
-            fi
-          done
-          cd ..
-          
       - name: Setup SSH Key
         if: steps.changes.outputs.has_changes == 'true' || github.event_name != 'schedule'
         uses: webfactory/ssh-agent@v0.9.0
@@ -205,13 +194,9 @@ jobs:
             --prerelease \
             --target main \
             nightly_assets/app-playstore-nightly.apk \
-            nightly_assets/app-playstore-nightly.apk.sha256 \
             nightly_assets/app-playstore-nightly.aab \
-            nightly_assets/app-playstore-nightly.aab.sha256 \
             nightly_assets/app-fdroid-nightly.apk \
-            nightly_assets/app-fdroid-nightly.apk.sha256 \
             nightly_assets/app-fdroid-nightly.aab \
-            nightly_assets/app-fdroid-nightly.aab.sha256 \
             nightly_assets/web_build.zip
 
       - name: Add immutable nightly tag for traceability

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,16 +360,6 @@ jobs:
           zip -r web_build.zip web_build/
           cd ..
 
-      - name: Generate Checksums
-        run: |
-          cd release_assets
-          for file in *.apk *.aab; do
-            if [ -f "$file" ]; then
-              sha256sum "$file" > "$file.sha256"
-            fi
-          done
-          cd ..
-      
       - name: Setup SSH Key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -441,13 +431,9 @@ jobs:
               - `repertoire-linux-v...zip` (Extract and run `./repertoire`)
           files: |
             ./release_assets/app-universal-playstore-release.apk
-            ./release_assets/app-universal-playstore-release.apk.sha256
             ./release_assets/app-playstore-release.aab
-            ./release_assets/app-playstore-release.aab.sha256
             ./release_assets/app-universal-fdroid-release.apk
-            ./release_assets/app-universal-fdroid-release.apk.sha256
             ./release_assets/app-fdroid-release.aab
-            ./release_assets/app-fdroid-release.aab.sha256
             ./release_assets/web_build.zip
           draft: false
           prerelease: ${{ github.event.inputs.prerelease }}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -26,7 +26,7 @@
   "appLanguage": "App Language",
   "languageName": "English",
   "appTheme": "App Theme",
-  "appTitle": "Music Repertoire",
+  "appTitle": "Repertoire",
   "@appTitle": {
     "description": "The application title"
   },
@@ -918,7 +918,7 @@
   "modifyGroups": "Modify Groups",
   "musicPieceUpdatedSuccessfully": "Music piece updated successfully.",
   "musicPieces": "Music Pieces",
-  "musicRepertoireApp": "Music Repertoire App",
+  "musicRepertoireApp": "Repertoire",
   "needsAttention": "Needs attention",
   "never": "Never",
   "neverPracticed": "Never practiced",
@@ -967,7 +967,7 @@
   "openLink": "Open Link",
   "openLogs": "Open Logs",
   "openingFolderSelector": "Opening folder selector...",
-  "organizeYourMusicPiecesAttachMediaAndTrackYourPracticeJourney": "Organize your music pieces, attach media, and track your practice journey.",
+  "organizeYourMusicPiecesAttachMediaAndTrackYourPracticeJourney": "Organize your pieces, attach media, and track your practice journey.",
   "other": "Other",
   "outline": "Outline",
   "outlineText": "Outline Text",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -257,7 +257,7 @@ abstract class AppLocalizations {
   /// The application title
   ///
   /// In en, this message translates to:
-  /// **'Music Repertoire'**
+  /// **'Repertoire'**
   String get appTitle;
 
   /// No description provided for @appearanceAnswer.
@@ -2063,7 +2063,7 @@ abstract class AppLocalizations {
   /// No description provided for @musicRepertoireApp.
   ///
   /// In en, this message translates to:
-  /// **'Music Repertoire App'**
+  /// **'Repertoire'**
   String get musicRepertoireApp;
 
   /// No description provided for @needsAttention.
@@ -2291,7 +2291,7 @@ abstract class AppLocalizations {
   /// No description provided for @organizeYourMusicPiecesAttachMediaAndTrackYourPracticeJourney.
   ///
   /// In en, this message translates to:
-  /// **'Organize your music pieces, attach media, and track your practice journey.'**
+  /// **'Organize your pieces, attach media, and track your practice journey.'**
   String get organizeYourMusicPiecesAttachMediaAndTrackYourPracticeJourney;
 
   /// No description provided for @other.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -87,7 +87,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appTheme => 'App Theme';
 
   @override
-  String get appTitle => 'Music Repertoire';
+  String get appTitle => 'Repertoire';
 
   @override
   String get appearanceAnswer =>
@@ -1258,7 +1258,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get musicPieces => 'Music Pieces';
 
   @override
-  String get musicRepertoireApp => 'Music Repertoire App';
+  String get musicRepertoireApp => 'Repertoire';
 
   @override
   String get needsAttention => 'Needs attention';
@@ -1380,7 +1380,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get organizeYourMusicPiecesAttachMediaAndTrackYourPracticeJourney =>
-      'Organize your music pieces, attach media, and track your practice journey.';
+      'Organize your pieces, attach media, and track your practice journey.';
 
   @override
   String get other => 'Other';

--- a/lib/models/bookmark.dart
+++ b/lib/models/bookmark.dart
@@ -3,13 +3,15 @@ import 'package:flutter/material.dart'; // For Duration
 class Bookmark {
   final String id;
   final Duration timestamp;
+  final int? pageNumber; // Optional page number for PDFs
   String name;
   final Color? color; // Optional color for the bookmark
   final String? mediaItemId; // Optional ID of the media item this bookmark belongs to
 
   Bookmark({
     required this.id,
-    required this.timestamp,
+    this.timestamp = Duration.zero,
+    this.pageNumber,
     required this.name,
     this.color,
     this.mediaItemId,
@@ -19,6 +21,7 @@ class Bookmark {
   Map<String, dynamic> toJson() => {
         'id': id,
         'timestamp': timestamp.inMilliseconds, // Store as milliseconds
+        'pageNumber': pageNumber,
         'name': name,
         'color': color?.toARGB32(), // Store color as int value
         'mediaItemId': mediaItemId,
@@ -27,7 +30,8 @@ class Bookmark {
   // Create a Bookmark object from a JSON-compatible Map
   factory Bookmark.fromJson(Map<String, dynamic> json) => Bookmark(
         id: json['id'],
-        timestamp: Duration(milliseconds: json['timestamp']),
+        timestamp: Duration(milliseconds: json['timestamp'] ?? 0),
+        pageNumber: json['pageNumber'],
         name: json['name'],
         color: json['color'] != null ? Color(json['color']) : null,
         mediaItemId: json['mediaItemId'],
@@ -37,6 +41,7 @@ class Bookmark {
   Bookmark copyWith({
     String? id,
     Duration? timestamp,
+    int? pageNumber,
     String? name,
     Color? color,
     String? mediaItemId,
@@ -44,6 +49,7 @@ class Bookmark {
     return Bookmark(
       id: id ?? this.id,
       timestamp: timestamp ?? this.timestamp,
+      pageNumber: pageNumber ?? this.pageNumber,
       name: name ?? this.name,
       color: color ?? this.color,
       mediaItemId: mediaItemId ?? this.mediaItemId,

--- a/lib/screens/audio_player_widget.dart
+++ b/lib/screens/audio_player_widget.dart
@@ -75,8 +75,17 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
     _player.player.seek(newPos);
   }
 
+  bool _wasPlayingBeforeScrub = false;
+
   void _startSkipTimer(bool forward, bool fine) {
     _skipTimer?.cancel();
+    
+    // Remember play state and pause to avoid jittery audio playback during continuous scrub
+    _wasPlayingBeforeScrub = _player.player.playing;
+    if (_wasPlayingBeforeScrub) {
+      _player.player.pause();
+    }
+    
     _skip(forward, fine: fine);
 
     // Use a periodic timer for rapid skipping
@@ -88,6 +97,12 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
   void _stopSkipTimer() {
     _skipTimer?.cancel();
     _skipTimer = null;
+    
+    // Resume playback if it was playing before scrubbing
+    if (_wasPlayingBeforeScrub) {
+      _player.player.play();
+      _wasPlayingBeforeScrub = false;
+    }
   }
 
   Future<void> _initializeSequence() async {

--- a/lib/screens/audio_player_widget.dart
+++ b/lib/screens/audio_player_widget.dart
@@ -43,6 +43,10 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
   final Uuid _uuid = Uuid(); // For generating unique bookmark IDs.
   late Future<void> _playerInitFuture;
   Timer? _skipTimer;
+  Timer? _delayTimer;
+  double _delaySeconds = 0.0;
+  bool _isSettingDelay = false;
+  bool _isCountingDown = false;
 
   @override
   void initState() {
@@ -53,6 +57,83 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
         .where((b) => b.mediaItemId == currentMediaId || b.mediaItemId == null)
         .toList();
     _playerInitFuture = _initializeSequence();
+  }
+
+  Future<void> _playAudio(bool isMyAudio) async {
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+    final l10n = context.l10n;
+    try {
+      if (!_isInitialized || !isMyAudio) {
+        await _initAudio();
+      } else {
+        await _player.play();
+      }
+    } catch (e) {
+      AppLogger.log('AudioPlayerWidget: Error in play button: $e');
+      scaffoldMessenger.showSnackBar(
+        SnackBar(content: Text(l10n.errorPlayingAudio(e.toString()))),
+      );
+    }
+  }
+
+  void _startSettingDelay() {
+    setState(() {
+      _isSettingDelay = true;
+      _delaySeconds = 0.0;
+    });
+    
+    _delayTimer?.cancel();
+    _delayTimer = Timer.periodic(const Duration(milliseconds: 50), (timer) {
+      if (mounted) {
+        setState(() {
+          _delaySeconds += 0.05;
+        });
+      }
+    });
+  }
+
+  void _stopSettingDelayAndStartCountdown(bool isMyAudio) {
+    _delayTimer?.cancel();
+    if (_delaySeconds < 0.5) {
+      // Didn't hold long enough, treat as a normal tap
+      setState(() {
+        _isSettingDelay = false;
+        _isCountingDown = false;
+      });
+      _playAudio(isMyAudio);
+      return;
+    }
+
+    setState(() {
+      _isSettingDelay = false;
+      _isCountingDown = true;
+      _delaySeconds = _delaySeconds.ceilToDouble(); // Start cleanly at full seconds
+    });
+
+    _delayTimer = Timer.periodic(const Duration(milliseconds: 50), (timer) {
+      if (mounted) {
+        setState(() {
+          _delaySeconds -= 0.05;
+          if (_delaySeconds <= 0) {
+            _delaySeconds = 0;
+            _isCountingDown = false;
+            timer.cancel();
+            _playAudio(isMyAudio);
+          }
+        });
+      }
+    });
+  }
+
+  void _cancelDelay() {
+    _delayTimer?.cancel();
+    if (mounted) {
+      setState(() {
+        _isSettingDelay = false;
+        _isCountingDown = false;
+        _delaySeconds = 0.0;
+      });
+    }
   }
 
   void _skip(bool forward, {int seconds = 1, bool fine = false}) {
@@ -285,6 +366,8 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
   void dispose() {
     _saveBookmarks(); // Save bookmarks when the widget is disposed.
     _skipTimer?.cancel();
+    _delayTimer?.cancel();
+    _player.dispose();
     super.dispose();
   }
 
@@ -386,35 +469,44 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
                         onPressed: _player.pause,
                       );
                     } else {
-                      mainButton = IconButton(
-                        icon: const Icon(Icons.play_arrow),
-                        iconSize: 64.0,
-                        onPressed: () async {
-                          final scaffoldMessenger = ScaffoldMessenger.of(
-                            context,
-                          );
-                          final l10n = context.l10n;
-                          try {
-                            // Always init if not my audio, effectively switching source
-                            if (!_isInitialized || !isMyAudio) {
-                              await _initAudio();
-                            } else {
-                              await _player.play();
-                            }
-                          } catch (e) {
-                            AppLogger.log(
-                              'AudioPlayerWidget: Error in play button: $e',
-                            );
-                            scaffoldMessenger.showSnackBar(
-                              SnackBar(
-                                content: Text(
-                                  l10n.errorPlayingAudio(e.toString()),
+                      if (_isSettingDelay || _isCountingDown) {
+                        mainButton = GestureDetector(
+                          onTap: _cancelDelay,
+                          child: SizedBox(
+                            width: 80.0,
+                            height: 80.0,
+                            child: Stack(
+                              alignment: Alignment.center,
+                              children: [
+                                SizedBox(
+                                  width: 64.0,
+                                  height: 64.0,
+                                  child: CircularProgressIndicator(
+                                    value: (_delaySeconds % 1.0 == 0.0 && _delaySeconds > 0) ? 1.0 : (_delaySeconds % 1.0),
+                                    strokeWidth: 6.0,
+                                    backgroundColor: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2),
+                                    valueColor: AlwaysStoppedAnimation<Color>(Theme.of(context).colorScheme.primary),
+                                  ),
                                 ),
-                              ),
-                            );
-                          }
-                        },
-                      );
+                                Text(
+                                  _delaySeconds.ceil().toString(),
+                                  style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      } else {
+                        mainButton = GestureDetector(
+                          onTap: () => _playAudio(isMyAudio),
+                          onLongPressStart: (_) => _startSettingDelay(),
+                          onLongPressEnd: (_) => _stopSettingDelayAndStartCountdown(isMyAudio),
+                          child: const Padding(
+                            padding: EdgeInsets.all(8.0),
+                            child: Icon(Icons.play_arrow, size: 64.0),
+                          ),
+                        );
+                      }
                     }
 
                     // Return the Row with Skip buttons and Main button

--- a/lib/screens/audio_player_widget.dart
+++ b/lib/screens/audio_player_widget.dart
@@ -86,7 +86,7 @@ class _AudioPlayerWidgetState extends State<AudioPlayerWidget> {
     _delayTimer = Timer.periodic(const Duration(milliseconds: 50), (timer) {
       if (mounted) {
         setState(() {
-          _delaySeconds += 0.05;
+          _delaySeconds += 0.10; // Count up at double speed (2 seconds per real second)
         });
       }
     });

--- a/lib/screens/midi_player_widget.dart
+++ b/lib/screens/midi_player_widget.dart
@@ -265,8 +265,15 @@ class _MidiPlayerWidgetState extends State<MidiPlayerWidget> {
         throw Exception(l10n.midiFileNotFound(mediaItem.pathOrUrl));
       }
 
+      ByteData soundFontData;
+      try {
+        soundFontData = await rootBundle.load('assets/soundfonts/TimGM6mb.sf2');
+      } catch (_) {
+        soundFontData = await rootBundle.load('packages/repertoire/assets/soundfonts/TimGM6mb.sf2');
+      }
+
       _synth = Synthesizer.loadByteData(
-        await rootBundle.load('assets/soundfonts/TimGM6mb.sf2'),
+        soundFontData,
         SynthesizerSettings(sampleRate: 44100),
       );
 

--- a/lib/screens/midi_player_widget_mobile.dart
+++ b/lib/screens/midi_player_widget_mobile.dart
@@ -264,8 +264,15 @@ class _MidiPlayerWidgetState extends State<MidiPlayerWidget> {
         throw Exception(l10n.midiFileNotFound(mediaItem.pathOrUrl));
       }
 
+      ByteData soundFontData;
+      try {
+        soundFontData = await rootBundle.load('assets/soundfonts/TimGM6mb.sf2');
+      } catch (_) {
+        soundFontData = await rootBundle.load('packages/repertoire/assets/soundfonts/TimGM6mb.sf2');
+      }
+
       _synth = Synthesizer.loadByteData(
-        await rootBundle.load('assets/soundfonts/TimGM6mb.sf2'),
+        soundFontData,
         SynthesizerSettings(sampleRate: 44100),
       );
 

--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -44,6 +44,7 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
 
   late AnimationController _scrollbarOpacityController;
   Timer? _scrollbarHideTimer;
+  Timer? _controlsHideTimer;
 
   @override
   void initState() {
@@ -61,6 +62,32 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
     _pdfViewerController.addListener(_onTransformationChanged);
     _loadSavedSpeed();
 
+    _resetControlsTimer();
+  }
+
+  void _resetControlsTimer() {
+    _controlsHideTimer?.cancel();
+    if (_showControls) {
+      _controlsHideTimer = Timer(const Duration(seconds: 4), () {
+        if (mounted && _showControls) {
+          setState(() {
+            _showControls = false;
+          });
+        }
+      });
+    }
+  }
+
+  void _toggleControls() {
+    setState(() {
+      _showControls = !_showControls;
+    });
+    if (_showControls) {
+      _resetControlsTimer();
+    } else {
+      _controlsHideTimer?.cancel();
+    }
+  }
     // Show initially, then fade out
     _showScrollbar();
   }
@@ -353,49 +380,64 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.grey[900],
-      appBar: AppBar(
-        title: Text(context.l10n.pdfViewer),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.zoom_out),
-            onPressed: () => _updateZoom(0.8),
-            tooltip: context.l10n.zoomOut,
-          ),
-          IconButton(
-            icon: const Icon(Icons.zoom_in),
-            onPressed: () => _updateZoom(1.2),
-            tooltip: context.l10n.zoomIn,
-          ),
-          IconButton(
-            icon: const Icon(Icons.settings_backup_restore),
-            onPressed: _resetZoom,
-            tooltip: context.l10n.resetZoom,
-          ),
-          if (widget.config.autoScrollEnabled && !_showControls)
-            IconButton(
-              icon: Icon(_isAutoScrolling ? Icons.pause : Icons.play_arrow),
-              onPressed: () => _toggleAutoScroll(!_isAutoScrolling),
-              tooltip: _isAutoScrolling
-                  ? context.l10n.pause
-                  : context.l10n.play,
+      extendBodyBehindAppBar: true,
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(kToolbarHeight),
+        child: AnimatedOpacity(
+          opacity: _showControls ? 1.0 : 0.0,
+          duration: const Duration(milliseconds: 300),
+          child: IgnorePointer(
+            ignoring: !_showControls,
+            child: AppBar(
+              backgroundColor: Theme.of(context).appBarTheme.backgroundColor?.withOpacity(0.8) ?? Colors.black87,
+              elevation: 0,
+              title: Text(context.l10n.pdfViewer),
+              actions: [
+                IconButton(
+                  icon: const Icon(Icons.zoom_out),
+                  onPressed: () => _updateZoom(0.8),
+                  tooltip: context.l10n.zoomOut,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.zoom_in),
+                  onPressed: () => _updateZoom(1.2),
+                  tooltip: context.l10n.zoomIn,
+                ),
+                IconButton(
+                  icon: const Icon(Icons.settings_backup_restore),
+                  onPressed: _resetZoom,
+                  tooltip: context.l10n.resetZoom,
+                ),
+                if (widget.config.autoScrollEnabled && !_showControls)
+                  IconButton(
+                    icon: Icon(_isAutoScrolling ? Icons.pause : Icons.play_arrow),
+                    onPressed: () => _toggleAutoScroll(!_isAutoScrolling),
+                    tooltip: _isAutoScrolling
+                        ? context.l10n.pause
+                        : context.l10n.play,
+                  ),
+                if (widget.config.autoScrollEnabled)
+                  IconButton(
+                    icon: Icon(
+                      _showControls ? Icons.visibility : Icons.visibility_off,
+                    ),
+                    onPressed: _toggleControls,
+                    tooltip: context.l10n.toggleControls,
+                  ),
+              ],
             ),
-          if (widget.config.autoScrollEnabled)
-            IconButton(
-              icon: Icon(
-                _showControls ? Icons.visibility : Icons.visibility_off,
-              ),
-              onPressed: () => setState(() => _showControls = !_showControls),
-              tooltip: context.l10n.toggleControls,
-            ),
-        ],
+          ),
+        ),
       ),
       body: Stack(
         children: [
           GestureDetector(
             onDoubleTap: _handleDoubleTap,
+            onTap: _toggleControls,
             child: Listener(
               behavior: HitTestBehavior.translucent,
               onPointerDown: (_) {
+                if (_showControls) _resetControlsTimer();
                 _showScrollbar();
                 if (_isAutoScrolling) {
                   _toggleAutoScroll(false);

--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -12,18 +12,26 @@ import 'package:url_launcher/url_launcher.dart';
 import 'dart:math' as math;
 import 'package:repertoire/utils/app_logger.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
+import 'package:uuid/uuid.dart';
 
 import 'package:repertoire/l10n/l10n.dart';
+import 'package:repertoire/models/music_piece.dart';
+import 'package:repertoire/models/bookmark.dart';
+import 'package:repertoire/database/music_piece_repository.dart';
 
 /// A screen for viewing PDF documents with optional auto-scroll and hyperlink support.
 class PdfViewerScreen extends StatefulWidget {
   final String pdfPath;
   final PdfConfig config;
+  final MusicPiece? musicPiece;
+  final int? mediaItemIndex;
 
   const PdfViewerScreen({
     super.key,
     required this.pdfPath,
     this.config = const PdfConfig(),
+    this.musicPiece,
+    this.mediaItemIndex,
   });
 
   @override
@@ -44,6 +52,10 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
   bool _isDraggingScrollbar = false;
   Duration _lastUpdateElapsed = Duration.zero;
 
+  List<Bookmark> _bookmarks = [];
+  final MusicPieceRepository _repository = MusicPieceRepository();
+  final Uuid _uuid = Uuid();
+
   late AnimationController _scrollbarOpacityController;
   Timer? _scrollbarHideTimer;
   Timer? _controlsHideTimer;
@@ -52,6 +64,14 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
   void initState() {
     super.initState();
     WakelockPlus.enable();
+    
+    if (widget.musicPiece != null && widget.mediaItemIndex != null) {
+      final currentMediaId = widget.musicPiece!.mediaItems[widget.mediaItemIndex!].id;
+      _bookmarks = widget.musicPiece!.bookmarks
+          .where((b) => b.mediaItemId == currentMediaId || b.mediaItemId == null)
+          .toList();
+    }
+
     _pdfViewerController = PdfViewerController();
     _scrollSpeed = widget.config.defaultSpeed;
     _ticker = createTicker(_onTick);
@@ -377,6 +397,142 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
     }
   }
 
+  Future<void> _saveBookmarks() async {
+    if (widget.musicPiece == null || widget.mediaItemIndex == null) return;
+    
+    // Update the piece's bookmarks (replacing those for this media item)
+    final currentMediaId = widget.musicPiece!.mediaItems[widget.mediaItemIndex!].id;
+    final otherBookmarks = widget.musicPiece!.bookmarks
+        .where((b) => b.mediaItemId != currentMediaId && b.mediaItemId != null)
+        .toList();
+    
+    widget.musicPiece!.bookmarks = [...otherBookmarks, ..._bookmarks];
+    
+    try {
+      await _repository.update(widget.musicPiece!);
+      AppLogger.log('PdfViewerScreen: Saved ${_bookmarks.length} bookmarks.');
+    } catch (e) {
+      AppLogger.log('PdfViewerScreen: Error saving bookmarks: $e');
+    }
+  }
+
+  Future<void> _addBookmark() async {
+    if (widget.musicPiece == null || widget.mediaItemIndex == null) return;
+    
+    final currentMediaId = widget.musicPiece!.mediaItems[widget.mediaItemIndex!].id;
+    final newBookmark = Bookmark(
+      id: _uuid.v4(),
+      pageNumber: _currentPage,
+      name: context.l10n.bookmarkDefaultName(_bookmarks.length + 1),
+      mediaItemId: currentMediaId,
+    );
+
+    setState(() {
+      _bookmarks.add(newBookmark);
+      // Sort by page number if possible
+      _bookmarks.sort((a, b) => (a.pageNumber ?? 0).compareTo(b.pageNumber ?? 0));
+    });
+    await _saveBookmarks();
+    
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Bookmark added at page $_currentPage')),
+      );
+    }
+  }
+
+  Future<void> _removeBookmark(String bookmarkId) async {
+    setState(() {
+      _bookmarks.removeWhere((b) => b.id == bookmarkId);
+    });
+    await _saveBookmarks();
+  }
+
+  void _showBookmarksSheet() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setSheetState) {
+            return Container(
+              padding: const EdgeInsets.all(16.0),
+              height: MediaQuery.of(context).size.height * 0.6,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        context.l10n.bookmarks,
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.close),
+                        onPressed: () => Navigator.pop(context),
+                      ),
+                    ],
+                  ),
+                  const Divider(),
+                  ElevatedButton.icon(
+                    onPressed: () async {
+                      await _addBookmark();
+                      setSheetState(() {});
+                    },
+                    icon: const Icon(Icons.bookmark_add),
+                    label: Text(context.l10n.addBookmark),
+                  ),
+                  const SizedBox(height: 16),
+                  Expanded(
+                    child: _bookmarks.isEmpty
+                        ? Center(child: Text(context.l10n.noBookmarksAddedYet))
+                        : ListView.builder(
+                            itemCount: _bookmarks.length,
+                            itemBuilder: (context, index) {
+                              final bookmark = _bookmarks[index];
+                              return Dismissible(
+                                key: Key(bookmark.id),
+                                direction: DismissDirection.endToStart,
+                                onDismissed: (direction) {
+                                  _removeBookmark(bookmark.id);
+                                  setSheetState(() {});
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(context.l10n.bookmarkDismissed(bookmark.name)),
+                                    ),
+                                  );
+                                },
+                                background: Container(
+                                  color: Colors.red,
+                                  alignment: Alignment.centerRight,
+                                  padding: const EdgeInsets.only(right: 20.0),
+                                  child: const Icon(Icons.delete, color: Colors.white),
+                                ),
+                                child: ListTile(
+                                  leading: const Icon(Icons.bookmark),
+                                  title: Text(bookmark.name),
+                                  subtitle: Text('Page ${bookmark.pageNumber ?? 1}'),
+                                  onTap: () {
+                                    if (bookmark.pageNumber != null) {
+                                      _pdfViewerController.goToPage(pageNumber: bookmark.pageNumber!);
+                                    }
+                                    Navigator.pop(context);
+                                  },
+                                ),
+                              );
+                            },
+                          ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
   @override
   void dispose() {
     _saveState();
@@ -409,6 +565,12 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
               elevation: 0,
               title: Text(context.l10n.pdfViewer),
               actions: [
+                if (widget.musicPiece != null && widget.mediaItemIndex != null)
+                  IconButton(
+                    icon: const Icon(Icons.bookmarks),
+                    onPressed: _showBookmarksSheet,
+                    tooltip: context.l10n.bookmarks,
+                  ),
                 IconButton(
                   icon: const Icon(Icons.zoom_out),
                   onPressed: () => _updateZoom(0.8),

--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -409,7 +409,7 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
     widget.musicPiece!.bookmarks = [...otherBookmarks, ..._bookmarks];
     
     try {
-      await _repository.update(widget.musicPiece!);
+      await _repository.updateMusicPiece(widget.musicPiece!);
       AppLogger.log('PdfViewerScreen: Saved ${_bookmarks.length} bookmarks.');
     } catch (e) {
       AppLogger.log('PdfViewerScreen: Error saving bookmarks: $e');

--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -4,12 +4,14 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/gestures.dart';
 import 'package:vector_math/vector_math_64.dart' show Vector3;
 import 'package:pdfrx/pdfrx.dart';
+import 'dart:convert';
 import 'dart:async';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:repertoire/models/pdf_config.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'dart:math' as math;
 import 'package:repertoire/utils/app_logger.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 import 'package:repertoire/l10n/l10n.dart';
 
@@ -49,6 +51,7 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
   @override
   void initState() {
     super.initState();
+    WakelockPlus.enable();
     _pdfViewerController = PdfViewerController();
     _scrollSpeed = widget.config.defaultSpeed;
     _ticker = createTicker(_onTick);
@@ -63,6 +66,9 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
     _loadSavedSpeed();
 
     _resetControlsTimer();
+    
+    // Show initially, then fade out
+    _showScrollbar();
   }
 
   void _resetControlsTimer() {
@@ -87,9 +93,6 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
     } else {
       _controlsHideTimer?.cancel();
     }
-  }
-    // Show initially, then fade out
-    _showScrollbar();
   }
 
   void _showScrollbar() {
@@ -363,8 +366,21 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
     _pdfViewerController.value = matrix;
   }
 
+  void _saveState() async {
+    if (!_isLoaded || _document == null) return;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final matrixList = _pdfViewerController.value.storage.toList();
+      await prefs.setString('pdf_matrix_${widget.pdfPath}', jsonEncode(matrixList));
+    } catch (e) {
+      AppLogger.log('Error saving PDF state: $e');
+    }
+  }
+
   @override
   void dispose() {
+    _saveState();
+    WakelockPlus.disable();
     _scrollbarHideTimer?.cancel();
     _scrollbarOpacityController.dispose();
     if (_ticker.isActive) {
@@ -469,12 +485,25 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
                     pageImageCachingDelay: Duration.zero,
                     partialImageLoadingDelay: Duration.zero,
                   ),
-                  onViewerReady: (document, controller) {
+                  onViewerReady: (document, controller) async {
                     if (mounted) {
                       setState(() {
                         _isLoaded = true;
                         _document = document;
                       });
+                      
+                      try {
+                        final prefs = await SharedPreferences.getInstance();
+                        final savedMatrixStr = prefs.getString('pdf_matrix_${widget.pdfPath}');
+                        if (savedMatrixStr != null) {
+                          final List<dynamic> decoded = jsonDecode(savedMatrixStr);
+                          final List<double> matrixList = decoded.map((e) => (e as num).toDouble()).toList();
+                          controller.value = Matrix4.fromList(matrixList);
+                          return; // State restored successfully
+                        }
+                      } catch (e) {
+                        AppLogger.log('Error loading PDF state: $e');
+                      }
                       
                       // Explicitly set zoom to fit page width/height to avoid starting zoomed in
                       final double fitScale = controller.alternativeFitScale == null

--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -448,6 +448,16 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
     await _saveBookmarks();
   }
 
+  Future<void> _renameBookmark(String bookmarkId, String newName) async {
+    setState(() {
+      final index = _bookmarks.indexWhere((b) => b.id == bookmarkId);
+      if (index != -1) {
+        _bookmarks[index] = _bookmarks[index].copyWith(name: newName);
+      }
+    });
+    await _saveBookmarks();
+  }
+
   void _showBookmarksSheet() {
     showModalBottomSheet(
       context: context,
@@ -513,6 +523,37 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
                                   leading: const Icon(Icons.bookmark),
                                   title: Text(bookmark.name),
                                   subtitle: Text('Page ${bookmark.pageNumber ?? 1}'),
+                                  trailing: IconButton(
+                                    icon: const Icon(Icons.edit, size: 20),
+                                    onPressed: () async {
+                                      final controller = TextEditingController(text: bookmark.name);
+                                      final newName = await showDialog<String>(
+                                        context: context,
+                                        builder: (context) => AlertDialog(
+                                          title: Text(context.l10n.renameBookmark),
+                                          content: TextField(
+                                            controller: controller,
+                                            autofocus: true,
+                                            onSubmitted: (value) => Navigator.of(context).pop(value),
+                                          ),
+                                          actions: [
+                                            TextButton(
+                                              onPressed: () => Navigator.of(context).pop(),
+                                              child: Text(context.l10n.cancel),
+                                            ),
+                                            TextButton(
+                                              onPressed: () => Navigator.of(context).pop(controller.text),
+                                              child: Text(context.l10n.rename),
+                                            ),
+                                          ],
+                                        ),
+                                      );
+                                      if (newName != null && newName.isNotEmpty && newName != bookmark.name) {
+                                        await _renameBookmark(bookmark.id, newName);
+                                        setSheetState(() {});
+                                      }
+                                    },
+                                  ),
                                   onTap: () {
                                     if (bookmark.pageNumber != null) {
                                       _pdfViewerController.goToPage(pageNumber: bookmark.pageNumber!);

--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -221,7 +221,13 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
 
   void _resetZoom() {
     if (!_pdfViewerController.isReady) return;
-    _pdfViewerController.goTo(Matrix4.identity());
+    final double fitScale = _pdfViewerController.alternativeFitScale == null
+        ? _pdfViewerController.coverScale
+        : math.min(
+            _pdfViewerController.coverScale,
+            _pdfViewerController.alternativeFitScale!,
+          );
+    _pdfViewerController.setZoom(_pdfViewerController.centerPosition, fitScale);
   }
 
   void _handleDoubleTap() {

--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -427,6 +427,15 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
                         _isLoaded = true;
                         _document = document;
                       });
+                      
+                      // Explicitly set zoom to fit page width/height to avoid starting zoomed in
+                      final double fitScale = controller.alternativeFitScale == null
+                          ? controller.coverScale
+                          : math.min(
+                              controller.coverScale,
+                              controller.alternativeFitScale!,
+                            );
+                      controller.setZoom(controller.centerPosition, fitScale);
                     }
                   },
                   onPageChanged: (page) {
@@ -515,8 +524,8 @@ class _PdfViewerScreenState extends State<PdfViewerScreen>
                                 height: thumbHeight,
                                 decoration: BoxDecoration(
                                   color: _isDraggingScrollbar
-                                      ? Colors.white70
-                                      : Colors.white38,
+                                      ? Colors.black87
+                                      : Colors.black54,
                                   borderRadius: BorderRadius.circular(4),
                                 ),
                               ),

--- a/lib/services/contributor_service.dart
+++ b/lib/services/contributor_service.dart
@@ -13,7 +13,15 @@ import 'package:repertoire/utils/app_logger.dart';
 /// This function reads the JSON file, decodes it, and maps the data
 /// to a list of [Contributor] objects, filtering out bots and action agents.
 Future<List<Contributor>> loadContributors() async {
-  final jsonString = await rootBundle.loadString('assets/contributors.json'); // Load the JSON string from assets.
+  String jsonString;
+  try {
+    jsonString = await rootBundle.loadString('assets/contributors.json');
+  } catch (_) {
+    // Fallback for when the app is built from a flavor directory (e.g. app_fdroid)
+    // where 'repertoire' acts as a package dependency.
+    jsonString = await rootBundle.loadString('packages/repertoire/assets/contributors.json');
+  }
+  
   final List<dynamic> jsonData = jsonDecode(jsonString); // Decode the JSON string into a list of dynamic objects.
   
   // Filter out bots and action agents

--- a/lib/widgets/media_display_widget.dart
+++ b/lib/widgets/media_display_widget.dart
@@ -382,6 +382,8 @@ class _MediaDisplayWidgetState extends State<MediaDisplayWidget> {
             builder: (context) => PdfViewerScreen(
               pdfPath: currentMediaItem.pathOrUrl,
               config: PdfConfig.fromJson(currentMediaItem.configData ?? '{}'),
+              musicPiece: widget.musicPiece,
+              mediaItemIndex: widget.mediaItemIndex,
             ),
           ),
         );


### PR DESCRIPTION
## Overview
This PR introduces a major round of polish and usability enhancements across the app's core media viewers, alongside critical bug fixes for asset loading and workflow optimizations. Highlights include a brand new delayed playback feature for audio, full bookmark support for PDFs, and significantly smoother audio scrubbing.

## Audio Player Enhancements
* **Smooth Audio Scrubbing:** Fixed an issue where continuously holding the skip buttons caused a jittery audio loop. The player now gracefully pauses playback on long-press and seamlessly resumes when released.
* **Delayed Playback (Countdown Setup):** Added a new feature tailored for dancers and solo musicians. 
* Long-pressing the Play button now acts as a countdown setter.
* An elegant circular progress indicator appears, counting up (at 2x speed for quick setup) for every second you hold it.
* Releasing the button locks in the delay, unwinds the visual timer, and automatically starts playback when it hits zero.

## PDF Viewer Polish & Bookmarks
* **PDF Bookmarks:** The PDF viewer now supports native bookmarking!
* Added a Bookmarks icon to the PDF App Bar that opens a dedicated management sheet.
* Users can add new bookmarks (which save the current page number), jump to existing bookmarks, swipe-to-delete, and rename them.
* *Note: The core `Bookmark` model was extended backward-compatibly, meaning old backups will restore perfectly without issue.*
* **Intelligent Auto-Hide UI:** The top App Bar and viewer controls now gracefully fade out after 4 seconds of inactivity, maximizing screen real estate for reading. Tapping the screen brings them back.
* **Persistent Zoom & Scroll:** The viewer now accurately remembers and restores your exact zoom scale and scroll matrix when exiting and returning to a document.
* **Quality of Life:** 
* Fixed the initial load state so documents open cleanly via `fitScale` instead of defaulting to an uncomfortable zoom.
* Changed the scrollbar thumb color to dark grey/black to ensure high contrast against standard white PDF pages.
* Integrated `wakelock_plus` to prevent the device screen from sleeping while actively reading a PDF.

## App Identity & Bug Fixes
* **App Identity:** Updated app strings from "Music Repertoire" to simply "Repertoire", reflecting its versatility for non-musician users.
* **Asset Loading Fixes:** Resolved runtime `Unable to load asset` exceptions affecting the Contributors page and MIDI soundfonts by implementing robust fallback asset paths.

## CI/CD Optimizations
* **Cleaner Releases:** Removed redundant standalone `.sha` file generation from the GitHub Actions workflows, as GitHub releases already display checksums natively.